### PR TITLE
docs: add codebase overview

### DIFF
--- a/README.md.txt
+++ b/README.md.txt
@@ -11,3 +11,14 @@ Main scenes:
 - `scenes/Main.tscn`
 - `scenes/Battle.tscn`
 - `scenes/Results.tscn`
+
+## Codebase Overview
+
+- `scenes/` – main Godot scenes such as the overworld, battle, and results screens.
+- `scripts/` – game logic and supporting code:
+  - `rpg/` contains the battle system, character data, progression, and related gameplay logic.
+  - `ui/` implements menus like character creation and the pause menu.
+  - `config/` holds tuning parameters and other configuration.
+  - `integrations/` includes interfaces to external services.
+- `plugins/` – editor plugins, currently including the Godot Git plugin.
+- `project.godot` – the Godot project configuration file.


### PR DESCRIPTION
## Summary
- document major directories in repository

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c10cd5e2008328a77b291a92f5fada