### PR TITLE
feat: implement sigil leveling and slotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,83 @@ Main scenes:
   - `integrations/` includes interfaces to external services.
 - `plugins/` – editor plugins, currently including the Godot Git plugin.
 - `project.godot` – the Godot project configuration file.
+## Psyokin – Dev Brief (for AI collaborator)
+
+### Repo/Engine/Branch info
+- **Repo:** psyokin
+- **Engine:** Godot 4.4.1
+- **Branch:** work (based on main)
+
+### High-level vision
+Psyokin is a top-down 2D RPG prototype focused on turn-based battles and party progression.
+
+### What’s implemented now
+- Basic overworld movement and battle transitions
+- Turn-based battle loop with party and enemy actors
+- Results screen summarizing encounter outcomes
+- Party seeding for quick development iteration
+
+### Key singletons/autoloads
+- `BattleContext` – passes encounter setup between scenes
+- `ResultsContext` – stores battle results for the results screen
+- `PartyState` – persistent roster of player characters
+- `OpenAIClient` – placeholder integration point for external AI
+- `BalanceTuning` – scene exposing runtime tuning knobs
+
+### Important scripts/scenes
+- `scenes/Main.tscn` – overworld entry point
+- `scenes/Battle.tscn` – core battle scene
+- `scenes/Results.tscn` – post-battle summary
+- `scripts/rpg/PartyState.gd` – manages party members
+- `scripts/rpg/BattleContext.gd` – holds pending encounter info
+- `scripts/rpg/ResultsContext.gd` – temporary storage for battle outcomes
+- `scripts/config/Tuning.gd` – exported balance variables
+- `scripts/integrations/OpenAIClient.gd` – example external service hook
+
+### Coding conventions
+- UTF-8 encoding enforced via `.editorconfig`
+- 8-space indentation in GDScript
+- `snake_case` for functions and variables
+- `PascalCase` for classes
+- Heavily commented headers summarizing each script’s role
+
+### How to run
+1. Install Godot 4.4.1.
+2. Open `project.godot` in the editor.
+3. Press **F5** to play.
+
+### Tuning knobs
+- `scripts/config/Tuning.gd` exports HP-related sliders used by `BalanceTuning`
+- Adjust `HP_BASE_*`, `HP_PER_STA_*`, and `HP_LVL_SCALE_*` to rebalance health formulas
+
+### Skills system state
+- `scripts/rpg/SkillsDB.gd` maps stat levels to unlocked skill IDs
+- Unlock tables exist for STR, STA, DEX, INTL, and CHA lines
+
+### Known pain points
+- Combat balance and skill effects are placeholder
+- No save/load; roster resets each run
+- Minimal UI polish
+- Limited documentation beyond this brief
+
+### “What I want you to do next” task list
+- Implement actual skill effects and integrate with battle actors
+- Add enemy AI behaviors and encounter variety
+- Persist party progression with a save system
+- Expand tuning system to cover more stats and mechanics
+- Improve battle and overworld UI/UX
+
+### Style & docs notes
+- Keep file headers with `WHAT/USE/RESPONSIBILITIES` sections
+- Document exported properties and singletons
+- Favor small, focused scripts over large monoliths
+
+### File-level notes
+- `scenes/Tuning.tscn` autoloads as `BalanceTuning` for live tweaking
+- `scripts/tests` contain smoke tests and debug overlays
+- `OpenAIClient.gd` is a stub for future integrations
+
+### How to verify
+- Launch `Main.tscn` and trigger a battle to ensure flow works
+- Adjust tuning sliders and confirm HP formula via `Tuning.describe()`
+- Run smoke tests in the editor to catch regressions

--- a/scripts/rpg/BattleActor.gd
+++ b/scripts/rpg/BattleActor.gd
@@ -20,6 +20,7 @@ var current_hp: int = 1
 
 # simple label (created at runtime)
 var _name_hp_label: Label
+var sigil_use_counts: Dictionary = {}
 
 # ------------------------------------------------------------------------------
 # Setup
@@ -52,7 +53,13 @@ func perform_basic_attack(target: BattleActor) -> int:
 	var dodge: int = RPGRules.atk_dodge(target.data)
 	if acc < dodge:
 		return 0
-	return max(0, base)
+        return max(0, base)
+
+func record_sigil_use(s: Sigil) -> void:
+        if s == null:
+                return
+        var c: int = int(sigil_use_counts.get(s, 0))
+        sigil_use_counts[s] = c + 1
 
 # ------------------------------------------------------------------------------
 # Damage & death

--- a/scripts/rpg/BattleScene.gd
+++ b/scripts/rpg/BattleScene.gd
@@ -339,23 +339,30 @@ func _finish_and_show_results() -> void:
 		var xp_before: int = a.data.xp
 		var xptn_before: int = a.data.xp_to_next
 
-		var levels_gained: int = a.data.add_xp(xp_total)
+                var levels_gained: int = a.data.add_xp(xp_total)
 
-		var lvl_after: int = a.data.level
-		var xp_after: int = a.data.xp
-		var xptn_after: int = a.data.xp_to_next
+                if a.data.bracelet != null:
+                        for s in a.data.bracelet.equipped_sigils():
+                                var gain := 1
+                                if a.sigil_use_counts.has(s):
+                                        gain += int(a.sigil_use_counts[s])
+                                s.gain_xp(gain)
 
-		allies_summary.append({
-			"name": a.data.name,
-			"level_before": lvl_before,
-			"level_after": lvl_after,
-			"xp_gained": xp_total,
-			"xp_before": xp_before,
-			"xp_to_next_before": xptn_before,
-			"xp_after": xp_after,
-			"xp_to_next_after": xptn_after,
-			"levels_gained": levels_gained
-		})
+                var lvl_after: int = a.data.level
+                var xp_after: int = a.data.xp
+                var xptn_after: int = a.data.xp_to_next
+
+                allies_summary.append({
+                        "name": a.data.name,
+                        "level_before": lvl_before,
+                        "level_after": lvl_after,
+                        "xp_gained": xp_total,
+                        "xp_before": xp_before,
+                        "xp_to_next_before": xptn_before,
+                        "xp_after": xp_after,
+                        "xp_to_next_after": xptn_after,
+                        "levels_gained": levels_gained
+                })
 
 	if _results_bus != null:
 		_results_bus.set_results(allies_summary, _captured.duplicate(), [], return_scene_path)

--- a/scripts/rpg/Bracelet.gd
+++ b/scripts/rpg/Bracelet.gd
@@ -63,11 +63,15 @@ func added_affinities() -> Array[int]:
 	return out
 
 # Optional helpers for code-driven socketing
-func add_sigil(s: Sigil) -> bool:
-	if sigils.size() >= slot_count:
-		return false
-	sigils.append(s)
-	return true
+func add_sigil(s: Sigil, mind_type: String = "OMEGA") -> bool:
+        if sigils.size() >= slot_count:
+                return false
+        if s == null:
+                return false
+        if not s.compatible_with(mind_type):
+                return false
+        sigils.append(s)
+        return true
 
 func remove_sigil(s: Sigil) -> bool:
 	var idx := sigils.find(s)

--- a/scripts/rpg/CharacterData.gd
+++ b/scripts/rpg/CharacterData.gd
@@ -16,6 +16,7 @@ class_name CharacterData
 
 # --- Identity -----------------------------------------------------------------
 var name: String = "Unknown"
+var mind_type: String = "OMEGA"
 
 # --- Progression --------------------------------------------------------------
 var level: int = 1
@@ -70,26 +71,26 @@ func total_armor_limit() -> int:
 	return lim
 
 # Effective stats (hook for equipment bonuses if/when you add them)
+func _bracelet_bonus(stat: String) -> int:
+        if bracelet != null and bracelet.has_method("total_bonuses"):
+                var t: Dictionary = bracelet.total_bonuses()
+                return int(t.get(stat, 0))
+        return 0
+
 func eff_str() -> int:
-	return strength
+        return strength + _bracelet_bonus("str")
 
 func eff_sta() -> int:
-	var bonus: int = 0
-	if bracelet != null:
-		if bracelet.has_method("get"):
-			bonus = int(bracelet.get("bonus_sta"))
-		elif "bonus_sta" in bracelet:
-			bonus = int(bracelet.bonus_sta)
-	return sta + bonus
+        return sta + _bracelet_bonus("sta")
 
 func eff_dex() -> int:
-	return dex
+        return dex + _bracelet_bonus("dex")
 
 func eff_int() -> int:
-	return intl
+        return intl + _bracelet_bonus("int")
 
 func eff_cha() -> int:
-	return cha
+        return cha + _bracelet_bonus("cha")
 
 # Max resource helpers (wrappers so old call sites like data.hp(rules) still work)
 func hp(_rules: RPGRules = null) -> int:

--- a/scripts/rpg/Sigil.gd
+++ b/scripts/rpg/Sigil.gd
@@ -12,6 +12,16 @@ class_name Sigil
 
 @export var name: String = "Sigil"
 
+# Which mind type this sigil belongs to ("void", "fire", "buff", etc.)
+# "ordinary" means it can be equipped by anyone.
+@export var sigil_type: String = "ordinary"
+
+# Progression ------------------------------
+@export var level: int = 1
+@export var xp: int = 0
+
+const LEVEL_XP: Array[int] = [0, 0, 30, 100, 300]
+
 # Flat stat bonuses while the sigil is socketed
 @export var bonus_str: int = 0
 @export var bonus_sta: int = 0
@@ -24,3 +34,22 @@ class_name Sigil
 
 # Placeholder for future expansion: skill unlocks granted by this sigil
 @export var unlock_skill_ids: Array[StringName] = []
+
+func xp_to_next() -> int:
+        if level >= LEVEL_XP.size() - 1:
+                return 0
+        return LEVEL_XP[level + 1]
+
+func gain_xp(amount: int) -> void:
+        if amount <= 0:
+                return
+        xp += amount
+        while level < LEVEL_XP.size() - 1 and xp >= LEVEL_XP[level + 1]:
+                level += 1
+
+func compatible_with(mind_type: String) -> bool:
+        if sigil_type == "ordinary":
+                return true
+        if mind_type.to_lower() == "omega":
+                return true
+        return sigil_type.to_lower() == mind_type.to_lower()


### PR DESCRIPTION
## Summary
- add XP progression and mind-type compatibility to Sigils
- gate Bracelet socketing by owner mind type and track sigil usage in battle
- propagate bracelet bonuses to character stats and award sigil XP after battles

## Testing
- `godot --headless --run scripts/tests/Bracelet_Sigil_SmokeTest.gd` *(fails: command not found: godot)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a6da271883289afd3f75a7295067