### PR TITLE
Fix: Unpause game tree when returning to title from GameMenu

### DIFF
--- a/scripts/main_menu/panels/SystemPanel.gd
+++ b/scripts/main_menu/panels/SystemPanel.gd
@@ -144,6 +144,12 @@ func _to_title() -> void:
 		aControllerManager.clear_stack()
 		aControllerManager.set_context(aControllerManager.InputContext.OVERWORLD)
 
+	# 3. CRITICAL: Unpause the game tree before changing scenes
+	# GameMenu pauses the game, but when we change scenes it gets destroyed
+	# before its visibility_changed callback can unpause, leaving the game stuck
+	print("[SystemPanel] Unpausing game tree")
+	get_tree().paused = false
+
 	# Use SceneRouter if available, otherwise change scene directly
 	if has_node("/root/aSceneRouter") and aSceneRouter.has_method("goto_title"):
 		print("[SystemPanel] Using SceneRouter.goto_title()")


### PR DESCRIPTION
When returning to title from GameMenu, the game tree remained paused because GameMenu's visibility_changed callback never ran (scene was destroyed during scene change). This left the title screen unable to accept any input.

Added explicit get_tree().paused = false before changing scenes to ensure the title screen loads in an unpaused state.

Fixed in SystemPanel._to_title() at line 151.